### PR TITLE
feat(dfu): add function to check pending verification

### DIFF
--- a/modules/dfu/include/libmcu/dfu.h
+++ b/modules/dfu/include/libmcu/dfu.h
@@ -168,6 +168,16 @@ bool dfu_is_valid_header(const struct dfu_image_header *header);
  */
 dfu_error_t dfu_invalidate(dfu_slot_t slot);
 
+/**
+ * @brief Checks if a verification process is pending for the firmware update.
+ *
+ * This function determines whether the firmware update requires verification
+ * before it can be finalized.
+ *
+ * @return true if verification is pending, false otherwise.
+ */
+bool dfu_is_pending_verify(void);
+
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
This pull request introduces a new API to the Device Firmware Update (DFU) module. The main change is the addition of a function to check if a firmware verification process is pending.

New DFU API:

* Added the `dfu_is_pending_verify()` function to `dfu.h`, which allows checking if a firmware update still requires verification before it can be finalized.