### PR TITLE
fix(retry): allow unlimited retries when max_attempts is zero

### DIFF
--- a/modules/retry/src/retry.c
+++ b/modules/retry/src/retry.c
@@ -45,7 +45,8 @@ static retry_error_t init(struct retry *self, const struct retry_param *param)
 
 static bool is_exhausted(const struct retry *self)
 {
-	return self->attempts >= self->param.max_attempts;
+	return self->param.max_attempts &&
+		self->attempts >= self->param.max_attempts;
 }
 
 static uint32_t calc_backoff_time(const struct retry *self,

--- a/tests/src/retry/retry_test.cpp
+++ b/tests/src/retry/retry_test.cpp
@@ -70,13 +70,15 @@ TEST(retry, ShouldReturnExhausted_WhenMaxAttemptsReached_WhenMaxAttempts1Given) 
 	LONGS_EQUAL(RETRY_ERROR_EXHAUSTED, retry_backoff(&retry, &actual, 0));
 }
 
-TEST(retry, ShouldReturnExhausted_WhenMaxAttemptsReached_WhenMaxAttempts0Given) {
+TEST(retry, ShouldRetryUnlimited_WhenMaxAttempts0Given) {
 	uint32_t actual;
 	struct retry_param param = {
 		.max_attempts = 0,
 	};
 	retry_new_static(&retry, &param);
-	LONGS_EQUAL(RETRY_ERROR_EXHAUSTED, retry_backoff(&retry, &actual, 0));
+	for (int i = 0; i < 100; i++) {
+		LONGS_EQUAL(RETRY_ERROR_NONE, retry_backoff(&retry, &actual, 0));
+	}
 }
 
 TEST(retry, ShouldReturnInvalidParam_WhenNullRetryGiven) {
@@ -111,12 +113,8 @@ TEST(retry, ShouldResetAttemptsAndPreviousBackOffMs) {
 TEST(retry, exhausted_ShouldReturnTrue_WhenExhausted) {
 	uint32_t actual;
 	struct retry_param param = {
-		.max_attempts = 0,
+		.max_attempts = 1,
 	};
-	retry_new_static(&retry, &param);
-	LONGS_EQUAL(true, retry_exhausted(&retry));
-
-	param.max_attempts = 1;
 	retry_new_static(&retry, &param);
 	LONGS_EQUAL(RETRY_ERROR_NONE, retry_backoff(&retry, &actual, 0));
 	LONGS_EQUAL(true, retry_exhausted(&retry));


### PR DESCRIPTION
This pull request updates the retry logic to clarify the behavior when `max_attempts` is set to zero, treating it as "unlimited retries" rather than immediately exhausted. The tests have been updated to reflect and verify this new behavior.

**Retry logic changes:**

* Updated `is_exhausted` in `retry.c` so that when `max_attempts` is zero, retries are unlimited and exhaustion never occurs.

**Test updates:**

* Changed the test for zero `max_attempts` to expect unlimited retries instead of exhaustion (`ShouldRetryUnlimited_WhenMaxAttempts0Given`).
* Updated the exhaustion test to use `max_attempts = 1` for correct coverage of the exhausted state.