### PR TITLE
feat(metrics): add metrics_reset_if_set() function

### DIFF
--- a/modules/metrics/include/libmcu/metrics.h
+++ b/modules/metrics/include/libmcu/metrics.h
@@ -117,6 +117,13 @@ void metrics_increase_by(const metric_key_t key, const metric_value_t n);
 void metrics_reset(void);
 
 /**
+ * @brief Unsets the specified metric to an unset state.
+ *
+ * @param[in] key The metric key to be unset.
+ */
+void metrics_unset(const metric_key_t key);
+
+/**
  * @brief Checks if a specific metric is set.
  *
  * This function checks if the specified metric key has been set to a

--- a/modules/metrics/src/metrics.c
+++ b/modules/metrics/src/metrics.c
@@ -218,7 +218,7 @@ void metrics_increase_by(const metric_key_t key, const metric_value_t n)
 bool metrics_is_set(const metric_key_t key)
 {
 	metrics_lock();
-	bool is_set = is_metric_set(get_obj_from_key(key));
+	const bool is_set = is_metric_set(get_obj_from_key(key));
 	metrics_unlock();
 	return is_set;
 }
@@ -227,6 +227,17 @@ void metrics_reset(void)
 {
 	metrics_lock();
 	reset_all();
+	metrics_unlock();
+}
+
+void metrics_unset(const metric_key_t key)
+{
+	metrics_lock();
+	struct metrics *p = get_obj_from_key(key);
+	if (is_metric_set(p)) {
+		p->value = 0;
+		p->is_set = false;
+	}
 	metrics_unlock();
 }
 

--- a/ports/esp-idf/cpuload.c
+++ b/ports/esp-idf/cpuload.c
@@ -7,6 +7,7 @@
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "libmcu/board.h"
 
 #define SEC_TO_USEC(sec)		((sec) * 1000 * 1000)
 #define MIN_TO_USEC(min)		((min) * 60 * 1000 * 1000)

--- a/tests/src/metrics/test_metrics.cpp
+++ b/tests/src/metrics/test_metrics.cpp
@@ -206,6 +206,26 @@ TEST(metrics, set_if_max_ShouldNotSetMaxValue_WhenSameValueGiven) {
 	LONGS_EQUAL(123, metrics_get(ReportInterval));
 }
 
+TEST(metrics, unset_ShouldResetMetric_WhenMetricIsSet) {
+	metrics_set(ReportInterval, 123);
+	LONGS_EQUAL(true, metrics_is_set(ReportInterval));
+	LONGS_EQUAL(123, metrics_get(ReportInterval));
+
+	metrics_unset(ReportInterval);
+	
+	LONGS_EQUAL(false, metrics_is_set(ReportInterval));
+	LONGS_EQUAL(0, metrics_get(ReportInterval));
+}
+
+TEST(metrics, unset_ShouldDoNothing_WhenMetricIsNotSet) {
+	LONGS_EQUAL(false, metrics_is_set(ReportInterval));
+	
+	metrics_unset(ReportInterval);
+	
+	LONGS_EQUAL(false, metrics_is_set(ReportInterval));
+	LONGS_EQUAL(0, metrics_get(ReportInterval));
+}
+
 TEST(metrics, test) {
 	metrics_set(WallTime, 10);
 	// 1. metrics_init()

--- a/tests/stubs/overrides/libmcu/metrics.h
+++ b/tests/stubs/overrides/libmcu/metrics.h
@@ -18,6 +18,7 @@ typedef uint16_t metric_key_t;
 #define metrics_increase(k)
 #define metrics_increase_by(k, n)
 #define metrics_reset()
+#define metrics_unset(k)
 #define metrics_iterate(f, a)
 #define metrics_collect(a, b)
 #define metrics_count()


### PR DESCRIPTION
This pull request adds a new function to the metrics module to allow resetting a specific metric only if it is set, along with corresponding tests and header updates. It also includes a minor code style improvement and a small include addition.

**Metrics module enhancements:**
* Added the `metrics_reset_if_set` function to both the header (`metrics.h`) and implementation (`metrics.c`), allowing a metric to be reset to an unset state only if it is currently set. [[1]](diffhunk://#diff-10443f976e6217ef7bce341398ef3a7398134d2523e51586782c0db1820b63a8R119-R128) [[2]](diffhunk://#diff-ca99a650d80f8677686a9fea3e066f9a0f789c17980aa577f8ca2b3b35832d3fR233-R243)
* Added unit tests for `metrics_reset_if_set` to verify correct behavior when the metric is set and when it is not set (`test_metrics.cpp`).
* Updated the metrics stub header to define `metrics_reset_if_set` for test builds.

**Code style and maintenance:**
* Changed the `is_set` variable in `metrics_is_set` to be declared as `const`, improving code clarity (`metrics.c`).

**Other changes:**
* Added `#include "libmcu/board.h"` in `cpuload.c` to ensure required dependencies are included.