### PR TITLE
feat(metrics): add periodic reporting with rate limiting

### DIFF
--- a/modules/metrics/README.md
+++ b/modules/metrics/README.md
@@ -18,7 +18,7 @@
 | `METRICS_DEFINE_PERCENTAGE(key)` | Ratio in [0, 100] |
 | `METRICS_DEFINE_TIMER(key, unit)` | Elapsed time; `unit`: `ms`/`MS`, `us`/`US`, `s`/`S` |
 | `METRICS_DEFINE_BYTES(key)` | Byte-count value |
-| `METRICS_DEFINE_BINARY(key)` | Binary value in [0, 1]; `unset` remains “no sample” |
+| `METRICS_DEFINE_BINARY(key)` | Binary value in [0, 1]; `unset` remains "no sample" |
 | `METRICS_DEFINE_STATE(key)` | Categorical / enum-like state value |
 
 [^1]: The default file name is `metrics.def`. You don't need to specify the file
@@ -33,10 +33,69 @@ You can implement your own encoder using `metrics_encode_header()` and
 `metrics_encode_each()`. No encoder by default, meaning just a simple byte
 stream.
 
+A ready-made [CBOR encoder](../../ports/metrics/cbor_encoder.c) is available
+under `ports/metrics/`. It encodes metrics as a CBOR map with device metadata
+(serial number, timestamp, version). Link the file and the
+[libcbor](https://github.com/libmcu/libcbor) dependency to use it.
+
 To get the exact encoded payload size before allocation, call
 `metrics_collect(NULL, 0)`.
 
-### Syncronization
+### Reporting
+
+`metrics_report()` drives a single collect-transmit cycle. Override the
+following hooks to integrate with your transport and application logic:
+
+| Hook | Role | Default |
+| ---- | ---- | ------- |
+| `metrics_report_prepare(ctx)` | Refresh metric values before collection (e.g. uptime, CPU load) | no-op |
+| `metrics_report_transmit(data, size, ctx)` | Send the encoded payload over the desired transport (HTTP, MQTT, UART, …) | returns `-ENOSYS` |
+
+Pass a `metricfs` instance to enable persistent storage: on transmit failure
+the payload is saved to `metricfs` and retransmitted on the next cycle. Pass
+`NULL` to disable persistence.
+
+```c
+uint8_t buf[256];
+struct metricfs *mfs = /* initialised metricfs instance, or NULL */;
+
+int err = metrics_report(buf, sizeof(buf), mfs, NULL);
+/* 0 = ok, -EAGAIN = unsent data remains in store, <0 = error */
+```
+
+For periodic reporting, use the convenience wrapper
+`metrics_report_periodic()`.  It calls `metrics_report()` only when the
+configured interval has elapsed (default 60 minutes).  If unsent data remains
+in `metricfs`, the interval is bypassed so the backlog drains immediately.
+
+Return values:
+
+| Value | Meaning |
+| ----- | ------- |
+| `0` | Report transmitted successfully |
+| `-EALREADY` | Interval not yet elapsed and no backlog — skipped |
+| `-EAGAIN` | Transmitted but unsent data still remains in store |
+| other `< 0` | Error (e.g. `-EINVAL`, `-ENOBUFS`) |
+
+The function is designed for repeated calls in a loop. When no backlog exists,
+calls within the interval return `-EALREADY` immediately with no I/O. When a
+backlog exists (e.g. after a transmit failure), the interval check is bypassed
+and every call attempts to drain the stored data until the backlog is cleared.
+
+```c
+/* Override the default 60-minute interval at compile time if needed:
+ *   -DMETRICS_REPORT_INTERVAL_SEC=300   (5 minutes) */
+
+while (1) {
+	int err;
+	do {
+		err = metrics_report_periodic(buf, sizeof(buf), mfs, NULL);
+	} while (err != -EALREADY);
+	sleep(10);
+}
+```
+
+### Synchronisation
 
 Implement `metrics_lock()` and `metrics_unlock()` in case of multi threaded
 environment.

--- a/modules/metrics/README.md
+++ b/modules/metrics/README.md
@@ -74,7 +74,7 @@ Return values:
 | ----- | ------- |
 | `0` | Report transmitted successfully |
 | `-EALREADY` | Interval not yet elapsed and no backlog — skipped |
-| `-EAGAIN` | Transmitted but unsent data still remains in store |
+| `-EAGAIN` | Unsent data remains in store |
 | other `< 0` | Error (e.g. `-EINVAL`, `-ENOBUFS`) |
 
 The function is designed for repeated calls in a loop. When no backlog exists,
@@ -104,10 +104,10 @@ environment.  This applies to all reporting APIs including
 ```c
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 
-void metircs_lock(void) {
+void metrics_lock(void) {
 	pthread_mutex_lock(&lock);
 }
-void metircs_unlock(void) {
+void metrics_unlock(void) {
 	pthread_mutex_unlock(&lock);
 }
 ```

--- a/modules/metrics/README.md
+++ b/modules/metrics/README.md
@@ -98,7 +98,8 @@ while (1) {
 ### Synchronisation
 
 Implement `metrics_lock()` and `metrics_unlock()` in case of multi threaded
-environment.
+environment.  This applies to all reporting APIs including
+`metrics_report_periodic()`.
 
 ```c
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;

--- a/modules/metrics/include/libmcu/metrics_reporter.h
+++ b/modules/metrics/include/libmcu/metrics_reporter.h
@@ -54,14 +54,17 @@ int metrics_report(void *buf, size_t bufsize, struct metricfs *mfs, void *ctx);
  * when unsent data remains in @p mfs.  On the very first call the report
  * always runs.
  *
- * Time is obtained via metrics_get_unix_timestamp().
+ * Time is obtained via metrics_get_unix_timestamp().  If the timestamp
+ * returns 0 (no RTC available), rate limiting is bypassed and every call
+ * runs a full report cycle.
  *
  * @param[in] buf     Encoding buffer (caller-owned).
  * @param[in] bufsize Size of the buffer in bytes.
  * @param[in] mfs     metricfs instance, or NULL.
  * @param[in] ctx     User context forwarded to hooks.
  *
- * @return 0 when skipped or succeeded.
+ * @return 0 on success.
+ * @return -EALREADY when skipped because the report interval has not elapsed.
  * @return -EAGAIN when unsent data remains.
  * @return negative errno on error.
  */

--- a/modules/metrics/include/libmcu/metrics_reporter.h
+++ b/modules/metrics/include/libmcu/metrics_reporter.h
@@ -46,6 +46,36 @@ struct metricfs;
  */
 int metrics_report(void *buf, size_t bufsize, struct metricfs *mfs, void *ctx);
 
+/**
+ * @brief Convenience wrapper that rate-limits metrics_report() calls.
+ *
+ * Calls metrics_report() only when at least @c METRICS_REPORT_INTERVAL_SEC
+ * seconds (default 3600) have elapsed since the last successful report, or
+ * when unsent data remains in @p mfs.  On the very first call the report
+ * always runs.
+ *
+ * Time is obtained via metrics_get_unix_timestamp().
+ *
+ * @param[in] buf     Encoding buffer (caller-owned).
+ * @param[in] bufsize Size of the buffer in bytes.
+ * @param[in] mfs     metricfs instance, or NULL.
+ * @param[in] ctx     User context forwarded to hooks.
+ *
+ * @return 0 when skipped or succeeded.
+ * @return -EAGAIN when unsent data remains.
+ * @return negative errno on error.
+ */
+int metrics_report_periodic(void *buf, size_t bufsize,
+		struct metricfs *mfs, void *ctx);
+
+/**
+ * @brief Resets the internal periodic timer state.
+ *
+ * Intended for testing.  After this call the next metrics_report_periodic()
+ * invocation will run unconditionally.
+ */
+void metrics_report_periodic_reset(void);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/modules/metrics/src/metrics_reporter.c
+++ b/modules/metrics/src/metrics_reporter.c
@@ -12,12 +12,17 @@
 #include <errno.h>
 #include <stdbool.h>
 
+#if !defined(METRICS_REPORT_INTERVAL_SEC)
+#define METRICS_REPORT_INTERVAL_SEC	3600U
+#endif
+
 static inline bool has_backlog(const struct metricfs *fs)
 {
 	return fs && metricfs_count(fs) > 0;
 }
 
-int metrics_report(void *buf, size_t bufsize, struct metricfs *mfs, void *ctx)
+static int report_once(void *buf, size_t bufsize,
+		struct metricfs *mfs, void *ctx)
 {
 	size_t len = 0;
 	bool from_store = false;
@@ -67,6 +72,42 @@ int metrics_report(void *buf, size_t bufsize, struct metricfs *mfs, void *ctx)
 
 	if (has_backlog(mfs)) {
 		return -EAGAIN;
+	}
+
+	return err;
+}
+
+int metrics_report(void *buf, size_t bufsize, struct metricfs *mfs, void *ctx)
+{
+	return report_once(buf, bufsize, mfs, ctx);
+}
+
+static uint64_t last_report_time;
+static bool periodic_initialized;
+
+void metrics_report_periodic_reset(void)
+{
+	last_report_time = 0;
+	periodic_initialized = false;
+}
+
+int metrics_report_periodic(void *buf, size_t bufsize,
+		struct metricfs *mfs, void *ctx)
+{
+	uint64_t now = metrics_get_unix_timestamp();
+
+	if (periodic_initialized) {
+		if (now - last_report_time < METRICS_REPORT_INTERVAL_SEC
+				&& !has_backlog(mfs)) {
+			return -EALREADY;
+		}
+	}
+
+	int err = report_once(buf, bufsize, mfs, ctx);
+
+	if (err == 0 || err == -EAGAIN) {
+		last_report_time = now;
+		periodic_initialized = true;
 	}
 
 	return err;

--- a/modules/metrics/src/metrics_reporter.c
+++ b/modules/metrics/src/metrics_reporter.c
@@ -96,7 +96,7 @@ int metrics_report_periodic(void *buf, size_t bufsize,
 {
 	uint64_t now = metrics_get_unix_timestamp();
 
-	if (periodic_initialized) {
+	if (periodic_initialized && now != 0) {
 		if (now - last_report_time < METRICS_REPORT_INTERVAL_SEC
 				&& !has_backlog(mfs)) {
 			return -EALREADY;

--- a/modules/metrics/src/metrics_reporter.c
+++ b/modules/metrics/src/metrics_reporter.c
@@ -105,7 +105,7 @@ int metrics_report_periodic(void *buf, size_t bufsize,
 
 	int err = report_once(buf, bufsize, mfs, ctx);
 
-	if (err == 0 || err == -EAGAIN) {
+	if ((err == 0 || err == -EAGAIN) && now != 0) {
 		last_report_time = now;
 		periodic_initialized = true;
 	}

--- a/tests/src/metrics/test_metrics_reporter.cpp
+++ b/tests/src/metrics/test_metrics_reporter.cpp
@@ -93,6 +93,12 @@ int metricfs_write(struct metricfs *fs,
 		.returnIntValue();
 }
 
+uint64_t metrics_get_unix_timestamp(void)
+{
+	return (uint64_t)mock().actualCall("get_timestamp")
+		.returnUnsignedLongIntValue();
+}
+
 static int fake_mfs_backing;
 static struct metricfs *mfs = (struct metricfs *)&fake_mfs_backing;
 static uint8_t buf[64];
@@ -629,4 +635,151 @@ TEST(MetricsReporter, ShouldDrainAllStoredEntriesBeforeSendingFresh) {
 	mock().expectOneCall("mfs_count")
 		.withParameter("fs", mfs).andReturnValue(0);
 	LONGS_EQUAL(0, metrics_report(buf, sizeof(buf), mfs, NULL));
+}
+
+/* =========================================================================
+ * metrics_report_periodic()
+ * ========================================================================= */
+
+TEST_GROUP(MetricsReporterPeriodic) {
+	void setup(void) {
+		memset(buf, 0, sizeof(buf));
+		metrics_report_periodic_reset();
+	}
+	void teardown(void) {
+		mock().checkExpectations();
+		mock().clear();
+	}
+};
+
+TEST(MetricsReporterPeriodic, ShouldReport_WhenCalledFirstTime) {
+	mock().expectOneCall("get_timestamp").andReturnValue(1000UL);
+	mock().expectOneCall("prepare").withParameter("ctx", (void *)NULL);
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	mock().expectOneCall("collect")
+		.withParameter("buf", buf)
+		.withParameter("bufsize", (int)sizeof(buf))
+		.andReturnValue((int)FAKE_PAYLOAD_LEN);
+	mock().expectOneCall("transmit")
+		.withParameter("data", buf)
+		.withParameter("datasize", (int)FAKE_PAYLOAD_LEN)
+		.withParameter("ctx", (void *)NULL)
+		.andReturnValue(0);
+	mock().expectOneCall("reset");
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	LONGS_EQUAL(0, metrics_report_periodic(buf, sizeof(buf), mfs, NULL));
+}
+
+TEST(MetricsReporterPeriodic, ShouldSkip_WhenIntervalNotElapsed) {
+	mock().expectOneCall("get_timestamp").andReturnValue(1000UL);
+	mock().expectOneCall("prepare").withParameter("ctx", (void *)NULL);
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	mock().expectOneCall("collect")
+		.withParameter("buf", buf)
+		.withParameter("bufsize", (int)sizeof(buf))
+		.andReturnValue((int)FAKE_PAYLOAD_LEN);
+	mock().expectOneCall("transmit")
+		.withParameter("data", buf)
+		.withParameter("datasize", (int)FAKE_PAYLOAD_LEN)
+		.withParameter("ctx", (void *)NULL)
+		.andReturnValue(0);
+	mock().expectOneCall("reset");
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	LONGS_EQUAL(0, metrics_report_periodic(buf, sizeof(buf), mfs, NULL));
+	mock().checkExpectations();
+	mock().clear();
+
+	mock().expectOneCall("get_timestamp").andReturnValue(1000UL + 1800UL);
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	LONGS_EQUAL(-EALREADY, metrics_report_periodic(buf, sizeof(buf), mfs, NULL));
+}
+
+TEST(MetricsReporterPeriodic, ShouldReport_WhenIntervalElapsed) {
+	mock().expectOneCall("get_timestamp").andReturnValue(1000UL);
+	mock().expectOneCall("prepare").withParameter("ctx", (void *)NULL);
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	mock().expectOneCall("collect")
+		.withParameter("buf", buf)
+		.withParameter("bufsize", (int)sizeof(buf))
+		.andReturnValue((int)FAKE_PAYLOAD_LEN);
+	mock().expectOneCall("transmit")
+		.withParameter("data", buf)
+		.withParameter("datasize", (int)FAKE_PAYLOAD_LEN)
+		.withParameter("ctx", (void *)NULL)
+		.andReturnValue(0);
+	mock().expectOneCall("reset");
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	LONGS_EQUAL(0, metrics_report_periodic(buf, sizeof(buf), mfs, NULL));
+	mock().checkExpectations();
+	mock().clear();
+
+	mock().expectOneCall("get_timestamp")
+		.andReturnValue(1000UL + 3600UL);
+	mock().expectOneCall("prepare").withParameter("ctx", (void *)NULL);
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	mock().expectOneCall("collect")
+		.withParameter("buf", buf)
+		.withParameter("bufsize", (int)sizeof(buf))
+		.andReturnValue((int)FAKE_PAYLOAD_LEN);
+	mock().expectOneCall("transmit")
+		.withParameter("data", buf)
+		.withParameter("datasize", (int)FAKE_PAYLOAD_LEN)
+		.withParameter("ctx", (void *)NULL)
+		.andReturnValue(0);
+	mock().expectOneCall("reset");
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	LONGS_EQUAL(0, metrics_report_periodic(buf, sizeof(buf), mfs, NULL));
+}
+
+TEST(MetricsReporterPeriodic, ShouldReportImmediately_WhenBacklogExists) {
+	mock().expectOneCall("get_timestamp").andReturnValue(1000UL);
+	mock().expectOneCall("prepare").withParameter("ctx", (void *)NULL);
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	mock().expectOneCall("collect")
+		.withParameter("buf", buf)
+		.withParameter("bufsize", (int)sizeof(buf))
+		.andReturnValue((int)FAKE_PAYLOAD_LEN);
+	mock().expectOneCall("transmit")
+		.withParameter("data", buf)
+		.withParameter("datasize", (int)FAKE_PAYLOAD_LEN)
+		.withParameter("ctx", (void *)NULL)
+		.andReturnValue(0);
+	mock().expectOneCall("reset");
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	LONGS_EQUAL(0, metrics_report_periodic(buf, sizeof(buf), mfs, NULL));
+	mock().checkExpectations();
+	mock().clear();
+
+	mock().expectOneCall("get_timestamp").andReturnValue(1000UL + 10UL);
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(1);
+	mock().expectOneCall("prepare").withParameter("ctx", (void *)NULL);
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(1);
+	mock().expectOneCall("mfs_peek_first")
+		.withParameter("fs", mfs)
+		.withParameter("buf", buf)
+		.withParameter("bufsize", (int)sizeof(buf))
+		.andReturnValue((int)FAKE_PAYLOAD_LEN);
+	mock().expectOneCall("transmit")
+		.withParameter("data", buf)
+		.withParameter("datasize", (int)FAKE_PAYLOAD_LEN)
+		.withParameter("ctx", (void *)NULL)
+		.andReturnValue(0);
+	mock().expectOneCall("mfs_del_first")
+		.withParameter("fs", mfs).andReturnValue(0);
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	LONGS_EQUAL(0, metrics_report_periodic(buf, sizeof(buf), mfs, NULL));
 }

--- a/tests/src/metrics/test_metrics_reporter.cpp
+++ b/tests/src/metrics/test_metrics_reporter.cpp
@@ -699,6 +699,47 @@ TEST(MetricsReporterPeriodic, ShouldSkip_WhenIntervalNotElapsed) {
 	LONGS_EQUAL(-EALREADY, metrics_report_periodic(buf, sizeof(buf), mfs, NULL));
 }
 
+TEST(MetricsReporterPeriodic, ShouldAlwaysReport_WhenTimestampReturnsZero) {
+	mock().expectOneCall("get_timestamp").andReturnValue(0UL);
+	mock().expectOneCall("prepare").withParameter("ctx", (void *)NULL);
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	mock().expectOneCall("collect")
+		.withParameter("buf", buf)
+		.withParameter("bufsize", (int)sizeof(buf))
+		.andReturnValue((int)FAKE_PAYLOAD_LEN);
+	mock().expectOneCall("transmit")
+		.withParameter("data", buf)
+		.withParameter("datasize", (int)FAKE_PAYLOAD_LEN)
+		.withParameter("ctx", (void *)NULL)
+		.andReturnValue(0);
+	mock().expectOneCall("reset");
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	LONGS_EQUAL(0, metrics_report_periodic(buf, sizeof(buf), mfs, NULL));
+	mock().checkExpectations();
+	mock().clear();
+
+	mock().expectOneCall("get_timestamp").andReturnValue(0UL);
+	mock().expectOneCall("prepare").withParameter("ctx", (void *)NULL);
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	mock().expectOneCall("collect")
+		.withParameter("buf", buf)
+		.withParameter("bufsize", (int)sizeof(buf))
+		.andReturnValue((int)FAKE_PAYLOAD_LEN);
+	mock().expectOneCall("transmit")
+		.withParameter("data", buf)
+		.withParameter("datasize", (int)FAKE_PAYLOAD_LEN)
+		.withParameter("ctx", (void *)NULL)
+		.andReturnValue(0);
+	mock().expectOneCall("reset");
+	mock().expectOneCall("mfs_count")
+		.withParameter("fs", mfs).andReturnValue(0);
+	LONGS_EQUAL(0, metrics_report_periodic(buf, sizeof(buf), mfs, NULL));
+}
+
+
 TEST(MetricsReporterPeriodic, ShouldReport_WhenIntervalElapsed) {
 	mock().expectOneCall("get_timestamp").andReturnValue(1000UL);
 	mock().expectOneCall("prepare").withParameter("ctx", (void *)NULL);


### PR DESCRIPTION
This pull request adds a new periodic reporting feature to the metrics module, allowing metrics to be reported at configurable intervals or immediately when there's a backlog. It introduces the `metrics_report_periodic()` API, updates documentation, and provides comprehensive tests for the new functionality.

**New periodic reporting API and documentation:**

* Added `metrics_report_periodic()` and `metrics_report_periodic_reset()` functions to `metrics_reporter.h` and implemented them in `metrics_reporter.c`. These functions allow metrics to be reported only after a configurable interval or immediately if unsent data exists, improving efficiency and reliability. [[1]](diffhunk://#diff-aceec46fe4adafe1b12be79bea712782afbdeaa3c29162f2442a120079e75905R49-R78) [[2]](diffhunk://#diff-e6952764f5aa8c71cd78611ee05063fd623bac44d3c9e28661069050eeabda89R15-R25) [[3]](diffhunk://#diff-e6952764f5aa8c71cd78611ee05063fd623bac44d3c9e28661069050eeabda89R79-R114)
* Updated `README.md` to document the new periodic reporting API, including usage examples, configuration options, and return values. Clarified the reporting workflow and persistence behavior.

**Testing improvements:**

* Added extensive unit tests for the new periodic reporting logic in `test_metrics_reporter.cpp`, covering first-time reporting, skipping when the interval hasn't elapsed, interval expiry, and backlog draining.
* Added a mock implementation of `metrics_get_unix_timestamp()` for testing time-based logic.

**Minor documentation fix:**

* Fixed a minor formatting issue in the `README.md` regarding the description of `METRICS_DEFINE_BINARY`.