### PR TITLE
fix(metrics): handle -EINPROGRESS in report_once

### DIFF
--- a/modules/metrics/src/metrics_reporter.c
+++ b/modules/metrics/src/metrics_reporter.c
@@ -86,6 +86,8 @@ static int report_once(void *buf, size_t bufsize,
 		} else {
 			metrics_reset();
 		}
+	} else if (err == -EINPROGRESS) {
+		return err;
 	} else if (!from_store && mfs) {
 		if (metricfs_write(mfs, buf, len, NULL) == 0) {
 			metrics_reset();


### PR DESCRIPTION
This pull request makes a targeted change to the `report_once` function in `metrics_reporter.c` to improve error handling. Specifically, it ensures that if the function encounters an `-EINPROGRESS` error, it returns immediately with that error code instead of proceeding further.

Error handling improvement:

* Updated `report_once` to return immediately when encountering an `-EINPROGRESS` error, preventing unnecessary processing in this case.